### PR TITLE
Change executable command and add README.md 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
 # command to install dependencies
 install:
   - pip install flake8
-  - pip install pep257
+  - pip install pydocstyle
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pydocstyle . --add-ignore=D202

--- a/README.jp.md
+++ b/README.jp.md
@@ -32,7 +32,7 @@ Package Control を使用することで、新しいバージョンが利用可�
 
 Package Control を使用してインストールするには、次の手順を実行します。
 
-1.Sublime Text 内で、[Command Palette](http://docs.sublimetext.info/ja/sublime-text-3/extensibility/command_palette.html) を開き、`Add Repository` と入力します。コマンドの中に `Package Control:Add Repository` があります。 そのコマンドが強調表示されていない場合は、キーボードまたはマウスを使用して選択します。  フォームが表示されるので、次の URL を入力します。
+1. Sublime Text 内で、[Command Palette](http://docs.sublimetext.info/ja/sublime-text-3/extensibility/command_palette.html) を開き、`Add Repository` と入力します。コマンドの中に `Package Control:Add Repository` があります。 そのコマンドが強調表示されていない場合は、キーボードまたはマウスを使用して選択します。  フォームが表示されるので、次の URL を入力します。
 
 ```
 https://github.com/taky/SublimeLinter-redpen
@@ -40,7 +40,7 @@ https://github.com/taky/SublimeLinter-redpen
 
 1. [Command Palette](http://docs.sublimetext.info/ja/sublime-text-3/extensibility/command_palette.html) を開き、 `install` と入力します。 コマンドの中には `Package Control:Install Package` があります。 その項目が強調表示されていない場合は、キーボードまたはマウスを使用して選択します。 パッケージコントロールが利用可能なプラグインのリストを取得する間、数秒間の時間がかかります。  
 
-1.プラグインリストが表示されたら、 `redpen` と入力します。 エントリの中に `SublimeLinter-redpen` があります。 その項目が強調表示されていない場合は、キーボードまたはマウスを使用して選択します。  
+1. プラグインリストが表示されたら、 `redpen` と入力します。 エントリの中に `SublimeLinter-redpen` があります。 その項目が強調表示されていない場合は、キーボードまたはマウスを使用して選択します。  
 
 ## プラグインの設定
 SublimeLinter の設定に関する一般的な情報は、[Settings](http://sublimelinter.readthedocs.org/ja/latest/settings.html) を参照してください。 一般的な  `linter` 設定の詳細については、[Linter Settings](http://sublimelinter.readthedocs.org/en/latest/linter_settings.html) を参照してください。
@@ -50,11 +50,11 @@ Tool > SublimeLinter> Open User Settings に移動して `conf` オプション�
 ## 参加方法
 改善や修正に貢献したい場合は、以下に従ってください。  
 
-1.リポジトリを folk します。
-1.最新の `master` から作成された別のトピックブランチをハックします。
-1.トピックブランチをコミットしてプッシュします。
-1.プルリクエストを行います。
-1.経過を待ってください。 ;-)  
+1. リポジトリを folk します。
+1. 最新の `master` から作成された別のトピックブランチをハックします。
+1. トピックブランチをコミットしてプッシュします。
+1. プルリクエストを行います。
+1. 経過を待ってください。 ;-)  
 
 変更は次のコーディングガイドラインに従ってください。  
 

--- a/README.jp.md
+++ b/README.jp.md
@@ -1,0 +1,65 @@
+# SublimeLinter module for RedPen 
+
+[![Build Status](https://travis-ci.org/taky/SublimeLinter-redpen.svg?branch=master)](https://travis-ci.org/taky/SublimeLinter-redpen)
+
+Copyright (c) 2015-2016 Takahiro Yoshimura <altakey@gmail.com>  
+Copyright (c) 2016 Ken Sakurai <sakurai.kem@gmail.com>  
+
+RedPen ( http://redpen.cc/ ) の SublimeLinter module プラグインです。  
+
+## SublimeLinter 3 のインストール
+このプラグインを使うには SublimeLinter 3 のインストールが必要になります。SublimeLinter 3 がインストールされていない場合、[こちら](http://sublimelinter.readthedocs.org/en/latest/installation.html)に従ってインストールを行ってください。  
+
+### Redpen のインストール
+このプラグインを使う前に、使用しているシステム上に `redpen` がインストールされていることを確認してください。 `redpen` をインストールするには、[ダウンロードページ](https://github.com/redpen-cc/redpen/releases/) から、`tar.gz` をダウンロードし、解凍してください。Mac OS X の場合、[Homebrew](http://brew.sh) を使いターミナル上で、以下のコマンドを入力することで、インストールできます。
+
+```sh
+brew install redpen
+```
+
+**注意点:** このプラグインは、`redpen` 1.7.0 以降のバージョンで動作確認をしています。
+
+### Redpen の設定
+ SublimeLinter で `redpen` を実行するには、SublimeLinter からパスが参照できる必要があります。  
+プラグインの実行前に、["Finding a linter executable"](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) "Validating your PATH" の手順を参照し、パスの設定を確認してください。
+ 
+ `redpen` をインストールし、設定が完了後、プラグインが使えるようになります。  
+
+### プラグインのインストール
+linter プラグインをインストールするには、[Package Control](https://sublime.wbond.net/installation) を使用してください。
+Package Control を使用することで、新しいバージョンが利用可能になったときにプラグインが更新されるようになります。  
+ソースからインストールする方法については、ここでは扱いません。  
+
+Package Control を使用してインストールするには、次の手順を実行します。
+
+1.Sublime Text 内で、[Command Palette](http://docs.sublimetext.info/ja/sublime-text-3/extensibility/command_palette.html) を開き、`Add Repository` と入力します。コマンドの中に `Package Control:Add Repository` があります。 そのコマンドが強調表示されていない場合は、キーボードまたはマウスを使用して選択します。  フォームが表示されるので、次の URL を入力します。
+
+```
+https://github.com/taky/SublimeLinter-redpen
+```
+
+1. [Command Palette](http://docs.sublimetext.info/ja/sublime-text-3/extensibility/command_palette.html) を開き、 `install` と入力します。 コマンドの中には `Package Control:Install Package` があります。 その項目が強調表示されていない場合は、キーボードまたはマウスを使用して選択します。 パッケージコントロールが利用可能なプラグインのリストを取得する間、数秒間の時間がかかります。  
+
+1.プラグインリストが表示されたら、 `redpen` と入力します。 エントリの中に `SublimeLinter-redpen` があります。 その項目が強調表示されていない場合は、キーボードまたはマウスを使用して選択します。  
+
+## プラグインの設定
+SublimeLinter の設定に関する一般的な情報は、[Settings](http://sublimelinter.readthedocs.org/ja/latest/settings.html) を参照してください。 一般的な  `linter` 設定の詳細については、[Linter Settings](http://sublimelinter.readthedocs.org/en/latest/linter_settings.html) を参照してください。
+
+Tool > SublimeLinter> Open User Settings に移動して `conf` オプションを設定することができます。 lint の `"conf"` の設定を `"conf" : "/path/to/file"` と設定することで、独自の設定ファイルを読み込むことができます。 Windows では、 `"conf" : "C:\\Users\\Aparajita\\redpen.conf"`  のように、パスのバックスラッシュを二重にしてください。  
+
+## 参加方法
+改善や修正に貢献したい場合は、以下に従ってください。  
+
+1.リポジトリを folk します。
+1.最新の `master` から作成された別のトピックブランチをハックします。
+1.トピックブランチをコミットしてプッシュします。
+1.プルリクエストを行います。
+1.経過を待ってください。 ;-)  
+
+変更は次のコーディングガイドラインに従ってください。  
+
+- インデントは4つのスペースです。
+- コードは、flake8 と pydocstyle の linters を渡す必要があります。
+- 縦の空白は可読性を向上させるため、積極的に使用してください。  
+
+ありがとう!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,61 @@
 # SublimeLinter module for RedPen #
 
-Copyright (C) 2015 Takahiro Yoshimura <altakey@gmail.com>
+[![Build Status](https://travis-ci.org/taky/SublimeLinter-redpen.svg?branch=master)](https://travis-ci.org/taky/SublimeLinter-redpen)
+
+Copyright (c) 2015-2016 Takahiro Yoshimura <altakey@gmail.com>  
+Copyright (c) 2016 Ken Sakurai <sakurai.kem@gmail.com>  
 
 SublimeLinter module for RedPen ( http://redpen.cc/ ).
+
+## Installation
+SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 3 is not installed, please follow the instructions [here](http://sublimelinter.readthedocs.org/en/latest/installation.html).
+
+### Linter installation
+Before installing this plugin, you must ensure that `redpen` is installed on your system. To install `redpen`, download and run `tar.gz` from the [download page](https://github.com/redpen-cc/redpen/releases/). On Mac OS X, the best option is to install [Homebrew](http://brew.sh) and then enter the following in a terminal:
+
+```sh
+brew install redpen
+```
+
+**Note:** This plugin requires `redpen` 1.7.0 or later.
+
+### Linter configuration
+In order for `redpen` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in [“Finding a linter executable”](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation.
+
+Once `redpen` is installed and configured, you can proceed to install the SublimeLinter-redpen plugin if it is not yet installed.
+
+### Plugin installation
+Please use [Package Control](https://sublime.wbond.net/installation) to install the linter plugin. This will ensure that the plugin will be updated when new versions are available. If you want to install from source so you can modify the source code, you probably know what you are doing so we won’t cover that here.
+
+To install via Package Control, do the following:
+
+1. Within Sublime Text, bring up the [Command Palette](http://docs.sublimetext.info/en/sublime-text-3/extensibility/command_palette.html) and type `Add Repository`. Among the commands you should see `Package Control: Add Repository`. If that command is not highlighted, use the keyboard or mouse to select it. Since Form will be displayed, enter the following URL.  
+```
+https://github.com/taky/SublimeLinter-redpen
+```
+
+1. Bring up the [Command Palette](http://docs.sublimetext.info/en/sublime-text-3/extensibility/command_palette.html) and type `install`. Among the commands you should see `Package Control: Install Package`. If that entry is not highlighted, use the keyboard or mouse to select it. There will be a pause of a few seconds while Package Control fetches the list of available plugins.
+
+1. When the plugin list appears, type `redpen`. Among the entries you should see `SublimeLinter-redpen`. If that entry is not highlighted, use the keyboard or mouse to select it.
+
+## Settings
+For general information on how SublimeLinter works with settings, please see [Settings](http://sublimelinter.readthedocs.org/en/latest/settings.html). For information on generic linter settings, please see [Linter Settings](http://sublimelinter.readthedocs.org/en/latest/linter_settings.html).
+
+You can configure `conf` options by going to: Tools > SublimeLinter > Open User Settings. You may provide a custom config file by setting the linter’s `"conf"` setting to `"conf" : "/path/to/file"`. On Windows, be sure to double the backslashes in the path, for example `"conf" : "C:\\Users\\Aparajita\\redpen.conf"`.
+
+## Contributing
+If you would like to contribute enhancements or fixes, please do the following:
+
+1. Fork the plugin repository.
+1. Hack on a separate topic branch created from the latest `master`.
+1. Commit and push the topic branch.
+1. Make a pull request.
+1. Be patient.  ;-)
+
+Please note that modications should follow these coding guidelines:
+
+- Indent is 4 spaces.
+- Code should pass flake8 and pydocstyle linters.
+- Vertical whitespace helps readability, don’t be afraid to use it.
+
+Thank you for helping out!

--- a/linter.py
+++ b/linter.py
@@ -1,50 +1,76 @@
 # linter.py: Entrypoint.
-# Copyright (c) 2015 Takahiro Yoshimura <altakey@gmail.com>
+# Copyright (c) 2015-2016 Takahiro Yoshimura <altakey@gmail.com>
+# Copyright (c) 2016 Ken Sakurai <sakurai.kem@gmail.com>
 
 """This module exports the RedPen plugin class."""
 
-from SublimeLinter.lint import Linter, persist
+from SublimeLinter.lint import Linter, persist, util
+import os.path
+import json
 
 
 class Redpen(Linter):
-
     """Provides an interface to RedPen."""
 
-    syntax = ('plain text', 'markdown', 'wiki')
-    executable = 'redpen-sublimelinter'
-
-    # We are missing out on some errors by ignoring multiline messages.
-    regex = (
-        r'^<stdin>:(?P<line>\d+):(?P<col>\d+): '
-        r'(?:(?P<error>(error|fatal error))|(?P<warning>warning)): '
-        r'(?P<message>.+)'
-    )
-
+    syntax = ('plain text', 'markdown', 'wiki', 'javaproperties', 'latex', 'asciidoc')
+    executable = 'redpen'
+    error_stream = util.STREAM_STDOUT
     defaults = {
-        'extra_flags': ""
+        'conf': '',
     }
-
-    base_cmd = (
-        'redpen-sublimelinter '
-    )
+    version_args = '--version'
+    version_re = r'(?P<version>\d+\.\d+\.\d+)'
+    version_requirement = '>= 1.7.0'
 
     def cmd(self):
-        """
-        Return the command line to execute.
-        """
-
-        result = self.base_cmd
-
+        """Return the command line to execute."""
+        command = [self.executable, '--result-format', 'json', '--format']
         try:
-            result += ' -%s ' % {
-                'plain text':'p',
-                'markdown':'m',
-                'wiki':'w'
-            }[persist.get_syntax(self.view)]
+            file_format = {'plain text': 'plain',
+                           'markdown': 'markdown',
+                           'wiki': 'wiki',
+                           'javaproperties': 'properties',
+                           'latex': 'latex',
+                           'asciidoc': 'asciidoc',
+                           }[persist.get_syntax(self.view)]
+            command.append(file_format)
         except KeyError:
-            pass
+            raise KeyError('Illegal syntax. \'{}\''.format(self.view))
 
         settings = self.get_view_settings()
-        result += settings.get('extra_flags', '')
+        conf_file_path = settings.get('conf', '')
+        if conf_file_path != '':
+            if os.path.exists(conf_file_path):
+                command.append('--conf')
+                command.append(conf_file_path)
+            else:
+                persist.printf('ERROR: Config file is not exist. \'{}\''.format(conf_file_path))
+        command.append('@')
+        return command
 
-        return result
+    def find_errors(self, output):
+        """
+        Convert json output into a set of matches SublimeLinter can process.
+
+        Redpen 's warning output format is a plain text format, it will be one line or multiple lines.
+        Since this behavior is difficult to handle in processing with regular expressions,
+        we will treat the warning output format as JSON.
+        """
+        data = json.loads(output)
+        data = data[0]
+        for error_json in data.get("errors", []):
+            yield self.split_match(error_json)
+
+    def split_match(self, error_json):
+        """Mapping the dictionary in the warning list to the screen display Taple."""
+        if "startPosition" in error_json:
+            start_position = error_json.get("startPosition", {})
+            col = start_position.get("offset", None)
+            line_num = start_position.get("lineNum", None)
+        else:
+            col = None
+            line_num = error_json.get("lineNum", None)
+
+        return error_json.get("sentence",
+                              None), None if line_num is None else line_num - 1, col, True, None, error_json.get(
+            "message", ""), None


### PR DESCRIPTION
Github から、linter プラグインをダウンロードして、動かそうとしたところ、動作しなかったので、
自分なりに動作するように変更してみました。  
以下、変更を加えました。

- executeable コマンドを、`redpen-sublimelinter` から、`redpen` に変更しました。
- README.md と、README.jp.md を追加しました。
- pep257 と、pydocstyle に変更しました。
